### PR TITLE
Update zh-CN.php

### DIFF
--- a/modules/editor/lang/zh-CN.php
+++ b/modules/editor/lang/zh-CN.php
@@ -96,6 +96,7 @@ $lang->edit['emoticon'] = '表情图标';
 $lang->edit['upload'] = '上传';
 $lang->edit['upload_file'] = '上传附件';
 $lang->edit['link_file'] = '插入附件';
+$lang->edit['delete_selected'] = '删除所选附件';
 $lang->edit['icon_align_article'] = '占一个段落';
 $lang->edit['icon_align_left'] = '文本左侧';
 $lang->edit['icon_align_middle'] = '居中对齐';


### PR DESCRIPTION
$lang->edit['delete_selected'] = '删除所选附件'; 누락된 부분

현재 제 사이트에서 테스트 해보니 본문 삽입 뒤에 출력되는 중문글자 수가 6개라 4개로 수정하면 외관적으로 적합할듯 싶어서 所选이란 단어를 빼면 될듯 싶습니다. 